### PR TITLE
Add support for stylesheet switching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "ng-switch" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [1.0.0]
 
 - Initial release
+
+## [1.1.0]
+
+- Added support for stylesheet switching support

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Press `cmd+y` or `ctrl+y` to make the switch!
 
 Or type `switch` in vscode command pallete(`Ctrl+Shift+P`)
 
+If in a stylesheet, pressing `Cmd+Y`/`Ctrl+Y` will switch to the templating file
+
 ## Release Notes
 
 Users appreciate release notes as you update your extension.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ng-switch",
 	"displayName": "ng-switch",
 	"description": "simple file switch between controller and template files in angular projects",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"publisher": "BharathRavi",
 	"icon": "icon.png",
 	"repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,23 +2,40 @@ import * as vscode from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand("ng-switch.switch", () => {
-    const path = vscode.window.activeTextEditor?.document.uri.fsPath || "";
-    var pathArr = path.split("/");
-    var isHtml = pathArr[pathArr.length - 1].endsWith(".html") ? true : false;
-    if (isHtml) {
-      pathArr[pathArr.length - 1] = pathArr[pathArr.length - 1].replace(
-        ".html",
-        ".ts"
+    const path: string =
+      vscode.window.activeTextEditor?.document.uri.fsPath || "";
+    var pathArr: string[] = path.split("/");
+    const isInsideNgFile: boolean = pathArr[pathArr.length - 1].includes(
+      ".component"
+    );
+    if (!isInsideNgFile) {
+      vscode.window.showWarningMessage(
+        "You are probably not inside an Angular component file"
       );
-    } else {
-      pathArr[pathArr.length - 1] = pathArr[pathArr.length - 1].replace(
-        ".ts",
-        ".html"
-      );
+      return;
     }
-    var openFilePath = pathArr.join("/");
-    var openPath = vscode.Uri.file(openFilePath);
-    vscode.workspace.openTextDocument(openPath).then((doc) => {
+    const fileNameArr: string[] = pathArr[pathArr.length - 1].split(".");
+    switch (fileNameArr[fileNameArr.length - 1]) {
+      case "ts":
+      case "css":
+      case "scss":
+      case "sass":
+      case "less":
+        fileNameArr[fileNameArr.length - 1] = "html";
+
+        pathArr[pathArr.length - 1] = fileNameArr.join(".");
+        break;
+      case "html":
+      default:
+        pathArr[pathArr.length - 1] = pathArr[pathArr.length - 1].replace(
+          ".html",
+          ".ts"
+        );
+        break;
+    }
+    var openFilePath: string = pathArr.join("/");
+    var vsCodeOpenPath: vscode.Uri = vscode.Uri.file(openFilePath);
+    vscode.workspace.openTextDocument(vsCodeOpenPath).then((doc) => {
       vscode.window.showTextDocument(doc);
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Official release updated to version 1.1.0.
  - Enhanced file switching now supports additional stylesheet formats and enforces proper Angular component detection.

- **Documentation**
  - Updated instructions clarify that pressing Cmd+Y (or Ctrl+Y) while in a stylesheet will switch to the corresponding templating file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->